### PR TITLE
Fix error detection in ApiClient

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,7 @@ interface APIStatusBarProps {
     isProcessing: boolean;
   };
   onRetryProcessing?: () => Promise<any>;
+  error?: string;
 }
 
 // ОБНОВЛЕННЫЙ APIStatusBar с полной интеграцией retry queue
@@ -36,7 +37,6 @@ const APIStatusBar: React.FC<APIStatusBarProps> = ({
   retryQueue,
   onRetryProcessing,
   error,
-  processingProgress,
 }) => {
   // Анализ карточек с ошибками (для обратной совместимости со старой системой)
   const cardsNeedingReprocessing = flashcards.filter(

--- a/client/src/services/ApiClient.ts
+++ b/client/src/services/ApiClient.ts
@@ -8,18 +8,21 @@ import {
   ErrorType,
 } from "../utils/error-handler";
 
+// Тип коллбэка слушателя событий
+type EventCallback = (...args: unknown[]) => void;
+
 // Простая браузерная реализация EventEmitter для избежания зависимости от Node.js
 class SimpleEventEmitter {
-  private events: Map<string, Function[]> = new Map();
+  private events: Map<string, EventCallback[]> = new Map();
 
-  on(event: string, listener: Function): void {
+  on(event: string, listener: EventCallback): void {
     if (!this.events.has(event)) {
       this.events.set(event, []);
     }
     this.events.get(event)!.push(listener);
   }
 
-  off(event: string, listener: Function): void {
+  off(event: string, listener: EventCallback): void {
     const listeners = this.events.get(event);
     if (listeners) {
       const index = listeners.indexOf(listener);
@@ -29,7 +32,7 @@ class SimpleEventEmitter {
     }
   }
 
-  emit(event: string, ...args: any[]): void {
+  emit(event: string, ...args: unknown[]): void {
     const listeners = this.events.get(event);
     if (listeners) {
       listeners.forEach(listener => {

--- a/client/src/services/ApiClient.ts
+++ b/client/src/services/ApiClient.ts
@@ -124,6 +124,11 @@ export class ApiClient extends SimpleEventEmitter {
           throw errorData;
         }
 
+        // Поддержка ошибок в виде строки "[Error: ...]" от callClaude
+        if (result.startsWith("[Error:")) {
+          throw new Error(result.slice(1, -1));
+        }
+
         // Успешный результат
         this.stats.successfulRequests++;
 

--- a/client/src/services/ApiClient.ts
+++ b/client/src/services/ApiClient.ts
@@ -124,9 +124,11 @@ export class ApiClient extends SimpleEventEmitter {
           throw errorData;
         }
 
-        // Поддержка ошибок в виде строки "[Error: ...]" от callClaude
-        if (result.startsWith("[Error:")) {
-          throw new Error(result.slice(1, -1));
+        // Поддержка ошибок в виде строки "[Error: ...]" или
+        // "[Claude API Error: ...]" от callClaude
+        const errorStringMatch = result.match(/^\[(?:Claude API )?Error: (.+)\]$/);
+        if (errorStringMatch) {
+          throw new Error(errorStringMatch[1]);
         }
 
         // Успешный результат

--- a/client/src/utils/error-handler.ts
+++ b/client/src/utils/error-handler.ts
@@ -1,13 +1,22 @@
 // Централизованная система анализа и классификации ошибок API
-export enum ErrorType {
-  PROXY_UNAVAILABLE = "proxy_unavailable", // прокси недоступен
-  NETWORK_ERROR = "network_error", // проблемы с интернетом
-  API_OVERLOADED = "api_overloaded", // API перегружен (529)
-  RATE_LIMITED = "rate_limited", // превышен лимит (429)
-  AUTHENTICATION = "authentication", // проблемы с API ключом (401, 403)
-  INSUFFICIENT_QUOTA = "insufficient_quota", // недостаточно средств (402)
-  UNKNOWN = "unknown", // прочие ошибки
-}
+export const ErrorType = {
+  PROXY_UNAVAILABLE: "proxy_unavailable", // прокси недоступен
+  NETWORK_ERROR: "network_error", // проблемы с интернетом
+  API_OVERLOADED: "api_overloaded", // API перегружен (529)
+  RATE_LIMITED: "rate_limited", // превышен лимит (429)
+  AUTHENTICATION: "authentication", // проблемы с API ключом (401, 403)
+  INSUFFICIENT_QUOTA: "insufficient_quota", // недостаточно средств (402)
+  UNKNOWN: "unknown", // прочие ошибки
+} as const;
+
+export type ErrorType =
+  | "proxy_unavailable"
+  | "network_error"
+  | "api_overloaded"
+  | "rate_limited"
+  | "authentication"
+  | "insufficient_quota"
+  | "unknown";
 
 export interface ErrorInfo {
   type: ErrorType;


### PR DESCRIPTION
## Summary
- detect `[Error: ...]` strings returned by `callClaude` in `ApiClient`

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/flashcards2/node_modules/globals/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_688337d219e4832592b78cf0dc4a711d