### PR TITLE
Fix card parsing and retry navigation reset

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -307,7 +307,7 @@ function App() {
     // НОВЫЕ поля для retry
     processRetryQueue,
     retryQueue,
-  } = useProcessing(inputText, setMode, setInputText);
+  } = useProcessing(inputText, setMode, setInputText, setCurrentIndex, setFlipped);
 
   // Колбэки для навигации по карточкам
   const handleIndexChange = React.useCallback((idx: number) => {

--- a/client/src/hooks/useProcessing.ts
+++ b/client/src/hooks/useProcessing.ts
@@ -36,7 +36,9 @@ interface ApiCard {
 export function useProcessing(
   inputText: string,
   setMode: (mode: AppMode) => void,
-  setInputText?: (text: string) => void
+  setInputText?: (text: string) => void,
+  setCurrentIndex?: (index: number) => void,
+  setFlipped?: (flipped: boolean) => void
 ) {
   // Основные состояния приложения
   const [state, setState] = React.useState<AppState>("input");
@@ -284,8 +286,8 @@ export function useProcessing(
                 word_form_translation: formTrans,
                 base_form: baseForm,
                 base_translation: baseTrans,
-                original_phrase: chunk,
-                phrase_translation: "",
+                original_phrase: card.original_phrase || chunk,
+                phrase_translation: card.phrase_translation || "",
                 text_forms: textForms,
                 visible: true,
               } as FlashcardOld,
@@ -391,6 +393,8 @@ export function useProcessing(
           setFlashcards(merged);
           generateTranslation(merged);
           setMode("flashcards");
+          setCurrentIndex?.(0);
+          setFlipped?.(false);
         }
 
         if (results.successful > 0) {
@@ -480,8 +484,10 @@ export function useProcessing(
       // Устанавливаем финальные данные
       setFlashcards(mergedCards);
       generateTranslation(mergedCards);
-      setState("ready");
       setMode("flashcards");
+      setCurrentIndex?.(0);
+      setFlipped?.(false);
+      setState("ready");
     } catch (error) {
       console.error("💥 Критическая ошибка обработки:", error);
       setState("input");


### PR DESCRIPTION
## Summary
- handle cards with no contexts by copying `original_phrase` and `phrase_translation`
- expose new parameters in `useProcessing` to reset flashcard view
- reset index and flip state after merging cards
- pass the new callbacks from `App`

## Testing
- `npm run type-check` *(fails: TS errors)*
- `npm run lint-and-format`
- `npm run lint:client`
- `npm run format:client`


------
https://chatgpt.com/codex/tasks/task_e_6886440c827c83258ae6b68ce9af8811