### PR TITLE
Fix edit view controls for reprocessing cards

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -395,6 +395,11 @@ function App() {
         console.log(`✅ Успешно обработано ${results.successful} из ${results.processed} чанков`);
       }
 
+      // После обработки всегда сбрасываем состояние просмотра
+      setCurrentIndex(0);
+      setFlipped(false);
+      setMode("flashcards");
+
       return results;
     } catch (error) {
       console.error("❌ Ошибка при retry:", error);
@@ -402,7 +407,7 @@ function App() {
     } finally {
       setRetryInProgress(false);
     }
-  }, [processRetryQueue, retryInProgress]);
+  }, [processRetryQueue, retryInProgress, setCurrentIndex, setFlipped, setMode]);
 
   const [apiError, setApiError] = React.useState(null);
 

--- a/client/src/components/EditView.tsx
+++ b/client/src/components/EditView.tsx
@@ -108,9 +108,9 @@ export const EditView: React.FC<EditViewProps> = ({
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {cards.map(card => {
-                const realIndex = flashcards.findIndex(originalCard => originalCard === card);
-                const isSystem =
+              {cards.map((card, idx) => {
+                const realIndex = startIndex + idx;
+                const needsReprocessing =
                   (card as { needsReprocessing?: boolean }).needsReprocessing === true;
 
                 return (
@@ -121,21 +121,21 @@ export const EditView: React.FC<EditViewProps> = ({
                   >
                     {/* VISIBLE checkbox */}
                     <td className="px-3 py-4">
-                      {!isSystem && (
-                        <input
-                          type="checkbox"
-                          checked={card.visible !== false}
-                          onChange={e => onCardUpdate(realIndex, "visible", e.target.checked)}
-                          className="h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
-                          data-testid="visibility-checkbox"
-                        />
-                      )}
+                      <input
+                        type="checkbox"
+                        disabled={needsReprocessing}
+                        checked={card.visible !== false}
+                        onChange={e => onCardUpdate(realIndex, "visible", e.target.checked)}
+                        className="h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+                        data-testid="visibility-checkbox"
+                      />
                     </td>
 
                     {/* BASE FORM */}
                     <td className="px-3 py-4">
                       <input
                         type="text"
+                        disabled={needsReprocessing}
                         value={card.base_form || ""}
                         onChange={e => onCardUpdate(realIndex, "base_form", e.target.value)}
                         placeholder="Введите базовую форму..."
@@ -149,6 +149,7 @@ export const EditView: React.FC<EditViewProps> = ({
                     <td className="px-3 py-4">
                       <input
                         type="text"
+                        disabled={needsReprocessing}
                         value={card.base_translation || ""}
                         onChange={e => onCardUpdate(realIndex, "base_translation", e.target.value)}
                         placeholder="Введите перевод..."
@@ -160,7 +161,7 @@ export const EditView: React.FC<EditViewProps> = ({
 
                     {/* ACTIONS */}
                     <td className="px-3 py-4 text-center">
-                      {!isSystem && (
+                      {!needsReprocessing && (
                         <button
                           onClick={() => onDeleteCard(realIndex)}
                           className="p-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded transition-colors"


### PR DESCRIPTION
## Summary
- disable visibility and edit inputs when a card needs reprocessing
- use stable index when mapping cards in edit view
- reset flashcard view after retry processing

## Testing
- `npm run lint -- --format codeframe`
- `npx tsc --noEmit --pretty` *(fails: found 45 errors in existing files)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6886576d64e483259f850b6eb0df3815