### PR TITLE
Add ProcessingService and update Jest setup

### DIFF
--- a/client/src/services/ProcessingService.ts
+++ b/client/src/services/ProcessingService.ts
@@ -1,0 +1,48 @@
+import { ApiClient } from "./ApiClient";
+import type { FlashcardNew } from "../types";
+import { normalizeCards, mergeCardsByBaseForm, textToCards } from "../utils/cardUtils";
+import { analyzeError } from "../utils/error-handler";
+
+export async function processTextOffline({
+  text,
+  apiClient,
+}: {
+  text: string;
+  apiClient: ApiClient;
+}): Promise<{ flashcards: FlashcardNew[]; translationText: string }> {
+  try {
+    const raw = await apiClient.request(text, { chunkInfo: "offline" });
+    const oldCards = textToCards(raw);
+    const normalized = normalizeCards(oldCards, text);
+    const merged = mergeCardsByBaseForm(normalized);
+
+    const translations = new Set<string>();
+    merged.forEach(card => {
+      card.contexts.forEach(ctx => {
+        const t = ctx.phrase_translation?.trim();
+        if (t) translations.add(t);
+      });
+    });
+
+    return {
+      flashcards: merged,
+      translationText: Array.from(translations).join(" "),
+    };
+  } catch (err) {
+    const errorInfo = analyzeError(err);
+    const errorCard: FlashcardNew = {
+      base_form: errorInfo.userMessage,
+      base_translation: errorInfo.recommendation,
+      contexts: [
+        {
+          original_phrase: text,
+          phrase_translation: errorInfo.recommendation,
+          text_forms: [],
+          word_form_translations: [],
+        },
+      ],
+      visible: true,
+    };
+    return { flashcards: [errorCard], translationText: "" };
+  }
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,8 +1,25 @@
 import "@testing-library/jest-dom";
-import "whatwg-fetch";
 
 // Polyfill TextEncoder/TextDecoder for msw in Node
 import { TextEncoder, TextDecoder } from "util";
+import { TransformStream } from "stream/web";
+
+// Simple in-memory localStorage mock
+class LocalStorageMock {
+  private store: Record<string, string> = {};
+  clear() {
+    this.store = {};
+  }
+  getItem(key: string) {
+    return this.store[key] ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.store[key] = value;
+  }
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -10,6 +27,26 @@ global.TextEncoder = TextEncoder;
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 global.TextDecoder = TextDecoder;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+global.TransformStream = TransformStream;
+// Provide localStorage in Node
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+global.localStorage = new LocalStorageMock();
+
+// Polyfill BroadcastChannel for msw in Node
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+global.BroadcastChannel = class {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_: string | undefined) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  postMessage(_: unknown) {}
+  close() {}
+  addEventListener() {}
+  removeEventListener() {}
+};
 
 // MSW server is not needed for current tests but kept for future use
 // If request handlers are added, uncomment the following lines:


### PR DESCRIPTION
## Summary
- add `processTextOffline` service for API processing
- polyfill `localStorage`, `BroadcastChannel`, and `TransformStream` in Jest setup

## Testing
- `npm run lint -- --format codeframe`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68866ccbd4f083258028824817f5c3a0