### PR TITLE
Fix Cypress fixture path and selectors

### DIFF
--- a/client/cypress/e2e/main.cy.ts
+++ b/client/cypress/e2e/main.cy.ts
@@ -10,7 +10,20 @@ describe("📘 E2E тесты приложения flashcards", () => {
   });
 
   it("1️⃣ Успешная обработка текста", () => {
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claude");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflight");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "success.json",
+      headers: {
+        "access-control-allow-origin": "*",
+      },
+    }).as("claude");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claude");
@@ -19,7 +32,17 @@ describe("📘 E2E тесты приложения flashcards", () => {
   });
 
   it("2️⃣ Ошибка сети при обработке", () => {
-    cy.intercept("POST", "**/api/claude", { forceNetworkError: true }).as("claudeError");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflightError");
+    cy.intercept("POST", "**/api/claude*", {
+      forceNetworkError: true,
+    }).as("claudeError");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claudeError");
@@ -28,18 +51,52 @@ describe("📘 E2E тесты приложения flashcards", () => {
   });
 
   it("3️⃣ Успешный Retry", () => {
-    cy.intercept("POST", "**/api/claude", { forceNetworkError: true }).as("firstFail");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflightFail");
+    cy.intercept("POST", "**/api/claude*", {
+      forceNetworkError: true,
+    }).as("firstFail");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@firstFail");
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claudeRetry");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflightRetry");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "success.json",
+      headers: {
+        "access-control-allow-origin": "*",
+      },
+    }).as("claudeRetry");
     cy.contains("Повторить").click();
     cy.wait("@claudeRetry");
     cy.get('[data-testid="flashcard"]').should("have.length.at.least", 2);
   });
 
   it("4️⃣ Удаление и добавление карточки", () => {
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claude");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflight4");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "success.json",
+      headers: { "access-control-allow-origin": "*" },
+    }).as("claude");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claude");
@@ -54,7 +111,18 @@ describe("📘 E2E тесты приложения flashcards", () => {
   });
 
   it("5️⃣ Экспорт и импорт карточек", () => {
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claude");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflight5");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "success.json",
+      headers: { "access-control-allow-origin": "*" },
+    }).as("claude");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claude");

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,5 +5,7 @@ export default defineConfig({
     specPattern: "client/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "client/cypress/support/e2e.ts",
     baseUrl: "http://localhost:5173",
+    chromeWebSecurity: false,
+    experimentalFetchPolyfill: true,
   },
 });

--- a/cypress/fixtures/success.json
+++ b/cypress/fixtures/success.json
@@ -1,0 +1,31 @@
+{
+  "flashcards": [
+    {
+      "base_form": "Anna",
+      "base_translation": "Анна",
+      "contexts": [
+        {
+          "original_phrase": "Anna pamostas agri.",
+          "phrase_translation": "Анна встает рано.",
+          "text_forms": ["Anna"]
+        }
+      ],
+      "visible": true
+    },
+    {
+      "base_form": "pamostas",
+      "base_translation": "встает",
+      "contexts": [
+        {
+          "original_phrase": "Anna pamostas agri.",
+          "phrase_translation": "Анна встает рано.",
+          "text_forms": ["pamostas"]
+        }
+      ],
+      "visible": true
+    }
+  ],
+  "translationText": "Анна встает рано.",
+  "formTranslations": [],
+  "version": "2.1"
+}


### PR DESCRIPTION
## Summary
- add fixture under `cypress/fixtures`
- adjust cypress config to allow cross-origin intercepts
- mock preflight requests in e2e tests

## Testing
- `npm run cypress:run` *(fails: Command failed with exit code 5)*

------
https://chatgpt.com/codex/tasks/task_e_688b54b0ef7083258136de00e7517593