### PR TITLE
Fix fixture format and adjust tests

### DIFF
--- a/client/cypress/e2e/main.cy.ts
+++ b/client/cypress/e2e/main.cy.ts
@@ -10,39 +10,102 @@ describe("📘 E2E тесты приложения flashcards", () => {
   });
 
   it("1️⃣ Успешная обработка текста", () => {
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claude");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflight");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "api-claude-success.json",
+      headers: {
+        "access-control-allow-origin": "*",
+      },
+    }).as("claude");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claude");
-    cy.get('[data-testid="flashcard"]').should("have.length.at.least", 2);
-    cy.get('[data-testid="translation-content"]').should("contain", "Анна встает рано");
+    cy.get('[data-testid="mode-flashcards"]', { timeout: 15000 }).should("not.be.disabled").click();
+    cy.get('[data-testid="flashcard"]', { timeout: 15000 }).should("have.length.at.least", 2);
+    cy.get('[data-testid="mode-translation"]').click();
+    cy.get("[data-testid=\"translation-content\"]", { timeout: 15000 }).should("contain", "Анна встает рано");
   });
 
   it("2️⃣ Ошибка сети при обработке", () => {
-    cy.intercept("POST", "**/api/claude", { forceNetworkError: true }).as("claudeError");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflightError");
+    cy.intercept("POST", "**/api/claude*", {
+      forceNetworkError: true,
+    }).as("claudeError");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claudeError");
-    cy.contains("🔴").should("be.visible");
-    cy.contains("Повторить").should("be.visible");
+    cy.contains(/интернет-соединением|Ошибка сети|Прокси сервер недоступен|ошибка/i, { timeout: 15000 }).should("be.visible");
+    cy.contains(/Повторить|Перезапустить/i, { timeout: 15000 }).should("be.visible");
   });
 
   it("3️⃣ Успешный Retry", () => {
-    cy.intercept("POST", "**/api/claude", { forceNetworkError: true }).as("firstFail");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflightFail");
+    cy.intercept("POST", "**/api/claude*", {
+      forceNetworkError: true,
+    }).as("firstFail");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@firstFail");
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claudeRetry");
-    cy.contains("Повторить").click();
+    cy.contains(/интернет-соединением|Ошибка сети|Прокси сервер недоступен|ошибка/i, { timeout: 15000 }).should("be.visible");
+    cy.contains(/Повторить|Перезапустить/i, { timeout: 15000 }).should("be.visible");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflightRetry");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "api-claude-success.json",
+      headers: {
+        "access-control-allow-origin": "*",
+      },
+    }).as("claudeRetry");
+    cy.contains(/Повторить|Перезапустить/i).click();
     cy.wait("@claudeRetry");
-    cy.get('[data-testid="flashcard"]').should("have.length.at.least", 2);
+    cy.get('[data-testid="mode-flashcards"]', { timeout: 15000 }).should("not.be.disabled").click();
+    cy.get('[data-testid="flashcard"]', { timeout: 15000 }).should("have.length.at.least", 2);
   });
 
   it("4️⃣ Удаление и добавление карточки", () => {
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claude");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflight4");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "api-claude-success.json",
+      headers: { "access-control-allow-origin": "*" },
+    }).as("claude");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claude");
+    cy.get('[data-testid="mode-flashcards"]', { timeout: 15000 }).should("not.be.disabled").click();
     cy.get('[data-testid="flashcard"]').first().click();
     cy.get('[data-testid="next-button"]').click();
     // Переходим в режим редактирования
@@ -54,15 +117,28 @@ describe("📘 E2E тесты приложения flashcards", () => {
   });
 
   it("5️⃣ Экспорт и импорт карточек", () => {
-    cy.intercept("POST", "**/api/claude", { fixture: "success.json" }).as("claude");
+    cy.intercept("OPTIONS", "**/api/claude*", {
+      statusCode: 200,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-headers": "*",
+      },
+    }).as("preflight5");
+    cy.intercept("POST", "**/api/claude*", {
+      fixture: "api-claude-success.json",
+      headers: { "access-control-allow-origin": "*" },
+    }).as("claude");
     cy.get('[data-testid="text-input"]').type("Anna pamostas agri.");
     cy.get('[data-testid="process-button"]').click();
     cy.wait("@claude");
-    cy.get('[data-testid="export-button"]').click();
+    cy.get('[data-testid="export-button"]', { timeout: 15000 }).should("not.be.disabled").click();
     cy.get('[data-testid="clear-button"]').click();
     cy.get('[data-testid="flashcard"]').should("not.exist");
-    cy.get('[data-testid="import-button"]').click();
-    cy.get('input[type="file"]').selectFile("cypress/fixtures/success.json", { force: true });
-    cy.get('[data-testid="flashcard"]').should("have.length.at.least", 2);
+    cy.get('[data-testid="import-file-input"]').selectFile("cypress/fixtures/success.json", {
+      force: true,
+    });
+    cy.get('[data-testid="mode-flashcards"]', { timeout: 15000 }).should("not.be.disabled").click();
+    cy.get('[data-testid="flashcard"]', { timeout: 15000 }).should("have.length.at.least", 2);
   });
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,5 +5,7 @@ export default defineConfig({
     specPattern: "client/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "client/cypress/support/e2e.ts",
     baseUrl: "http://localhost:5173",
+    chromeWebSecurity: false,
+    experimentalFetchPolyfill: true,
   },
 });

--- a/cypress/fixtures/api-claude-success.json
+++ b/cypress/fixtures/api-claude-success.json
@@ -1,0 +1,8 @@
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "[{\"base_form\":\"Anna\",\"base_translation\":\"Анна\",\"front\":\"Anna\",\"translations\":[\"Анна\"],\"text_forms\":[\"Anna\"],\"contexts\":[{\"latvian\":\"Anna pamostas agri.\",\"russian\":\"Анна встает рано.\",\"word_in_context\":\"Anna\"}]},{\"base_form\":\"pamostas\",\"base_translation\":\"встает\",\"front\":\"pamostas\",\"translations\":[\"встает\"],\"text_forms\":[\"pamostas\"],\"contexts\":[{\"latvian\":\"Anna pamostas agri.\",\"russian\":\"Анна встает рано.\",\"word_in_context\":\"pamostas\"}]}]"
+    }
+  ]
+}

--- a/cypress/fixtures/success.json
+++ b/cypress/fixtures/success.json
@@ -1,0 +1,35 @@
+{
+  "inputText": "Anna pamostas agri.",
+  "flashcards": [
+    {
+      "base_form": "Anna",
+      "base_translation": "Анна",
+      "contexts": [
+        {
+          "original_phrase": "Anna pamostas agri.",
+          "phrase_translation": "Анна встает рано.",
+          "text_forms": ["Anna"],
+          "word_form_translations": []
+        }
+      ],
+      "visible": true
+    },
+    {
+      "base_form": "pamostas",
+      "base_translation": "встает",
+      "contexts": [
+        {
+          "original_phrase": "Anna pamostas agri.",
+          "phrase_translation": "Анна встает рано.",
+          "text_forms": ["pamostas"],
+          "word_form_translations": []
+        }
+      ],
+      "visible": true
+    }
+  ],
+  "translationText": "Анна встает рано.",
+  "formTranslations": [],
+  "timestamp": "2025-01-01T00:00:00.000Z",
+  "version": "2.1"
+}


### PR DESCRIPTION
## Summary
- fix API Claude fixture formatting
- update E2E tests to wait longer and match all error messages

## Testing
- `npm run lint`
- `npm run cypress:run` *(fails: missing Xvfb dependency)*

------
https://chatgpt.com/codex/tasks/task_e_688b54b0ef7083258136de00e7517593