### PR TITLE
Fix API error detection logic

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -410,19 +410,20 @@ function App() {
     }
   }, [processRetryQueue, retryInProgress, setCurrentIndex, setFlipped, setMode]);
 
-  const [apiError, setApiError] = React.useState(null);
+  // Типизируем состояние ошибки API
+  const [apiError, setApiError] = React.useState<string | null>(null);
 
   // Добавьте useEffect для отслеживания ошибок:
   React.useEffect(() => {
     const step = (processingProgress.step || "").trim();
     if (
       step.includes("Ошибка") ||
-      step.includes("error") ||
+      step.toLowerCase().includes("error") ||
       step.startsWith("🔴") ||
       step.startsWith("🌐")
     ) {
       setApiError(step);
-    } else if (step === "ready") {
+    } else if (step === "ready" || step === "") {
       setApiError(null);
     }
   }, [processingProgress.step]);

--- a/cypress/downloads/latvian-learning-2025-08-01.json
+++ b/cypress/downloads/latvian-learning-2025-08-01.json
@@ -34,6 +34,6 @@
   ],
   "translationText": "Анна встает рано.",
   "formTranslations": [],
-  "timestamp": "2025-08-01T20:44:45.877Z",
+  "timestamp": "2025-08-01T21:22:13.832Z",
   "version": "2.1"
 }


### PR DESCRIPTION
## Summary
- improve error detection in `App.tsx`

## Testing
- `npm run lint:client -- --format codeframe`
- `npm run cypress:run` *(fails: `[data-testid="api-status-bar"]` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2dbe49048325b1e788ec7c74e88a